### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/ozmo/__init__.py
+++ b/ozmo/__init__.py
@@ -747,7 +747,7 @@ class EcoVacsIOTMQ(ClientMQTT):
 
     def schedule(self, timer_seconds, timer_function):
         self.scheduler.enter(timer_seconds, 1, self._run_scheduled_func,(timer_seconds, timer_function))
-        if not self.scheduler_thread.isAlive():
+        if not self.scheduler_thread.is_alive():
             self.scheduler_thread.start()
         
     def wait_until_ready(self):


### PR DESCRIPTION
`Thread.isAlive` was removed in Python 3.9 because it is an alias for `Thread.is_alive`. See https://bugs.python.org/issue37804.