### PR TITLE
1.0.4: Replace deprecated thread.is_alive and xml.getchildren methods

### DIFF
--- a/ozmo/__init__.py
+++ b/ozmo/__init__.py
@@ -747,7 +747,7 @@ class EcoVacsIOTMQ(ClientMQTT):
 
     def schedule(self, timer_seconds, timer_function):
         self.scheduler.enter(timer_seconds, 1, self._run_scheduled_func,(timer_seconds, timer_function))
-        if not self.scheduler_thread.isAlive():
+        if not self.scheduler_thread.is_alive():
             self.scheduler_thread.start()
         
     def wait_until_ready(self):

--- a/ozmo/__init__.py
+++ b/ozmo/__init__.py
@@ -873,7 +873,7 @@ class EcoVacsIOTMQ(ClientMQTT):
     def _ctl_to_dict_api(self, action, xmlstring):
         xml = ET.fromstring(xmlstring)
     
-        xmlchild = xml.getchildren()
+        xmlchild = list(xml)
         if len(xmlchild) > 0:
             result = xmlchild[0].attrib.copy()
             #Fix for difference in XMPP vs API response

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except FileNotFoundError:
 
 setup(
     name='ozmo',
-    version='1.0.3',
+    version='1.0.4',
 
     description='a library for controlling certain robot vacuums',
     long_description=long_description,


### PR DESCRIPTION
- Fixes the is_alive issue. Based on @sh00t2kill's branch (I just picked on of the three PRs that are currently open about this)
- Also fixes the xml.getchildren issue. The method was removed in python 3.9

How to try it locally:
- `pip3 install git+https://github.com/MajorBreakfast/ozmo`
- `ozmo login`
- `ozmo clean 10`