### PR TITLE
Handle missing type property in clean report

### DIFF
--- a/developing.md
+++ b/developing.md
@@ -15,7 +15,7 @@ like
 ```
 % python3 -m virtualenv env
 % source env/bin/activate
-% pip install -e .[dev]
+% pip install -e ".[dev]"
 % nosetests
 ```
 

--- a/ozmo/__init__.py
+++ b/ozmo/__init__.py
@@ -497,7 +497,7 @@ class VacBot():
         _LOGGER.debug("*** life_span " + type + " = " + str(lifespan))
 
     def _handle_clean_report(self, event):
-        type = event['type']
+        type = event.get('type', 'no_type_found')
         try:
             type = CLEAN_MODE_FROM_ECOVACS[type]
             if self.vacuum['iotmq']: #Was able to parse additional status from the IOTMQ, may apply to XMPP too

--- a/tests/test_vacbot.py
+++ b/tests/test_vacbot.py
@@ -29,6 +29,11 @@ def test_handle_clean_report():
     assert_equals('a_type_not_supported_by_ozmo', v.clean_status)
     assert_equals('a_weird_speed', v.fan_speed)
 
+    # Set a fake type when the vacuum didn't return the type property
+    v._handle_ctl({'event': 'clean_report', 'speed': 'a_weird_speed'})
+    assert_equals('no_type_found', v.clean_status)
+    assert_equals('a_weird_speed', v.fan_speed)
+
 
              
 def test_not_iot_send_command_clean():


### PR DESCRIPTION
With my Deebot OZMO Slim10, the `type` property of the `clean_report` is only returned when the vacuum is actually cleaning. If it's in standby or returning to the charger, it returns nothing.

This PR handles it by setting a default type when the property is not returned, with the same behaviour as when Ecovacs returns a unexpected value.